### PR TITLE
Fix segfault for expand with empty simple quotes and not supposed to …

### DIFF
--- a/src/exec/utils/utils.c
+++ b/src/exec/utils/utils.c
@@ -26,6 +26,7 @@ void	exit_error(t_data *data, int code, char *source)
 	{
 		write(2, " in \e[1m", 8);
 		write(2, source, ft_strlen(source));
+		write(2, "\n", 1);
 	}
 	free_quit(data);
 	exit(EXIT_FAILURE);

--- a/src/exec/utils/utils_free.c
+++ b/src/exec/utils/utils_free.c
@@ -47,7 +47,6 @@ void	free_quit(t_data *data)
 	free(data->p);
 	free_list(data->env);
 	free(data);
-	exit(EXIT_FAILURE);
 }
 
 void	close_parent_fd(t_data *data, int block)

--- a/src/parsing/cut_expand.c
+++ b/src/parsing/cut_expand.c
@@ -87,8 +87,6 @@ int	cutting_expand(t_data *data)
 			;
 		else if (temp->from_expand && !temp->in_quote)
 		{
-			if (remove_quotes(&data->tokens, data))
-				return (1);
 			array = ft_split(temp->token, ' ');
 			if (!array)
 				return (1);

--- a/src/parsing/rm_quotes.c
+++ b/src/parsing/rm_quotes.c
@@ -66,17 +66,20 @@ int	remove_quotes(t_token **tokens, t_data *data)
 	temp = *tokens;
 	while (temp)
 	{
-		new = malloc(sizeof(char) * (get_size(data->p, temp->token) + 1));
-		if (!new)
-			return (1);
-		copy_without_quotes(new, temp->token, data->p);
-		if (ft_strcmp(temp->token, new))
-			temp->in_quote = 1;
-		free(temp->token);
-		temp->token = ft_strdup(new);
-		if (!temp->token)
-			return (free(new), 1);
-		free(new);
+		if (!temp->from_expand)
+		{
+			new = malloc(sizeof(char) * (get_size(data->p, temp->token) + 1));
+			if (!new)
+				return (1);
+			copy_without_quotes(new, temp->token, data->p);
+			if (ft_strcmp(temp->token, new))
+				temp->in_quote = 1;
+			free(temp->token);
+			temp->token = ft_strdup(new);
+			if (!temp->token)
+				return (free(new), 1);
+			free(new);
+		}
 		temp = temp->next;
 	}
 	return (0);

--- a/src/utils/minishell.c
+++ b/src/utils/minishell.c
@@ -114,9 +114,9 @@ int	main(int argc, char **argv, char **envp)
 	t_data	*data;
 
 	(void)argv;
-	if (argc != 1)
-		return ((void)printf("Don't put args !\n"), 1);
 	data = ft_calloc(1, sizeof(t_data));
+	if (argc != 1 || !data)
+		return (1);
 	fill_env(data, envp);
 	while (1)
 	{


### PR DESCRIPTION
…do ec\'h\'o now keeps the quotes correctly.